### PR TITLE
Keep field name into a dedicated variable

### DIFF
--- a/helper/handle.js
+++ b/helper/handle.js
@@ -110,8 +110,9 @@ Handler.prototype.uploadFile = function * (ctx, action, options) {
         gfsOpt.mode = "w";
         gfsOpt.content_type = mime.lookup (part.filename);
         gfsOpt.filename = part.filename;
+        var fieldName = part.fieldname;
         var file = yield upload (ctx.gfs, gfsOpt, part);
-        form[part.fieldname || "file"] = file; 
+        form[fieldName || "file"] = file; 
       }
       else {
         form = _.merge (form, field(part));


### PR DESCRIPTION
When doing concurrent file upload, 'part' become undefined after the first upload, hence the assigning of form [<fieldname>] would fail becose part.fieldname couldn't be resolved
